### PR TITLE
Experimental/do not select 1 on retries

### DIFF
--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1209,14 +1209,8 @@ function sendRequestPreExec(statementContext, onResultAvailable)
   {
     disableOfflineChunks: false,
   };
-  if (!statementContext.resubmitRequest)
-  {
-    json.sqlText = statementContext.sqlText;
-  }
-  else
-  {
-    json.sqlText = 'select 1;';
-  }
+
+  json.sqlText = statementContext.sqlText;
 
   Logger.getInstance().debug('context.bindStage='+statementContext.bindStage);
   if (Util.exists(statementContext.bindStage))

--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1210,7 +1210,11 @@ function sendRequestPreExec(statementContext, onResultAvailable)
     disableOfflineChunks: false,
   };
 
-  json.sqlText = statementContext.sqlText;
+  if (statementContext.resubmitRequest && !statementContext.sqlText) {
+    json.sqlText = 'select 1;'
+  } else {
+    json.sqlText = statementContext.sqlText;
+  }
 
   Logger.getInstance().debug('context.bindStage='+statementContext.bindStage);
   if (Util.exists(statementContext.bindStage))


### PR DESCRIPTION
This PR introduced a bug on certain retries while trying to add a convenience feature: https://github.com/snowflakedb/snowflake-connector-nodejs/pull/338
The idea was that on retries the user can skip the sqlText, because the server already got the query and knows it so it's redundant. And that's totally true as long as the server got the query! Unfortunately, sometimes it's not true, because of network errors causing the request to not complete :(.

This problem manifests as retries sometimes resulting in  a one column one row result of `1`.

In those cases, the server gets `select 1` and a request ID for the first time, has no way of knowing that this is a retry of some sort, and correctly returns a one column one row result of `1`. Meanwhile, the caller has no way to know beyond knowing whether they expect a `1` back as a reasonable request or not.

This change only sets the sqlText to 'select 1' if the user didn't set one. I personally think the whole idea is pretty dubious, but no reason to break functionality that someone might want, I guess.