### PR TITLE
remove unused require, also change a require to use destructuring

### DIFF
--- a/lib/file_transfer_agent/gcs_util.js
+++ b/lib/file_transfer_agent/gcs_util.js
@@ -4,6 +4,7 @@
 
 const EncryptionMetadata = require('./encrypt_util').EncryptionMetadata;
 const FileHeader = require('./file_util').FileHeader;
+const { get, put, head } = require('axios');
 
 const GCS_METADATA_PREFIX = 'x-goog-meta-';
 const SFC_DIGEST = 'sfc-digest';
@@ -20,6 +21,12 @@ const CONTENT_CHUNK_SIZE = 10 * 1024;
 const HTTP_HEADER_CONTENT_ENCODING = 'Content-Encoding';
 const HTTP_HEADER_ACCEPT_ENCODING = 'Accept-Encoding';
 const resultStatus = require('./file_util').resultStatus;
+
+const defaultHttpClient = {
+  get: (...args) => get(...args),
+  put: (...args) => put(...args),
+  head: (...args) => head(...args),
+};
 
 const { Storage } = require('@google-cloud/storage');
 
@@ -43,7 +50,7 @@ function GCSLocation(bucketName, path)
  */
 function gcs_util(httpclient, filestream)
 {
-  const axios = typeof httpclient !== "undefined" ? httpclient : require('axios');
+  const axios = typeof httpclient !== "undefined" ? httpclient : defaultHttpClient;
   const fs = typeof filestream !== "undefined" ? filestream : require('fs');
 
   /**

--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -6,7 +6,7 @@ const zlib = require('zlib');
 const Util = require('../util');
 const Errors = require('../errors');
 const Logger = require('../logger');
-const axios = require('axios');
+const { request } = require('axios');
 const URL = require('node:url').URL;
 
 const DEFAULT_REQUEST_TIMEOUT = 360000;
@@ -38,7 +38,7 @@ HttpClient.prototype.getConnectionConfig = function ()
 HttpClient.prototype.request = function (options) {
   const requestOptions = prepareRequestOptions.call(this, options);
   let sendRequest = async function sendRequest() {
-    request = axios.request(requestOptions).then(response => {
+    request = request(requestOptions).then(response => {
       if (Util.isFunction(options.callback)) {
         return options.callback(null, normalizeResponse(response), response.data);
       } else {

--- a/lib/services/sf.js
+++ b/lib/services/sf.js
@@ -44,7 +44,6 @@
                - destroy()    - Disconnected
  */
 
-const axios = require('axios');
 const { v4: uuidv4 } = require('uuid');
 const EventEmitter = require('events').EventEmitter;
 const Util = require('../util');


### PR DESCRIPTION
Import via destructuring, which apparently is the "right way" to do things and could fix our errors, which can come from some commonjs/default exports thing I don't really understand.
- the actual problem file uses just `request`
- another file uses a few attributes, and does its import dynamically. I don't know if I did this right, really? But the current method sure seems like it could be an issue.
- Another file imports axios, but doesn't use it.