### PR TITLE
CD-8344 - Fix use of globals for Jest 28.

### DIFF
--- a/lib/connection/statement.js
+++ b/lib/connection/statement.js
@@ -1376,7 +1376,7 @@ function sendRequestPreExec(statementContext, onResultAvailable)
     true);
 }
 
-this.sendRequest = function (statementContext, onResultAvailable)
+globalThis.sendRequest = function (statementContext, onResultAvailable)
 {
   // get the request headers
   var headers = statementContext.resultRequestHeaders;

--- a/lib/http/base.js
+++ b/lib/http/base.js
@@ -38,7 +38,7 @@ HttpClient.prototype.getConnectionConfig = function ()
 HttpClient.prototype.request = function (options) {
   const requestOptions = prepareRequestOptions.call(this, options);
   let sendRequest = async function sendRequest() {
-    requestObject = request(requestOptions).then(response => {
+    globalThis.requestObject = request(requestOptions).then(response => {
       if (Util.isFunction(options.callback)) {
         return options.callback(null, normalizeResponse(response), response.data);
       } else {
@@ -67,8 +67,8 @@ HttpClient.prototype.request = function (options) {
   // methods we're comfortable exposing to the outside world
   return {
     abort: function () {
-      if (requestObject) {
-        requestObject.abort();
+      if (globalThis.requestObject) {
+        globalThis.requestObject.abort();
       }
     }
   };


### PR DESCRIPTION
Jest 28 and PNPM together somehow dislike the use of `this` and even _implicit_ `this` in `snowflake-sdk`. Replacing these usages seems to make all of the tests pass, and I haven't seen any negative side-effects. This PR is a prerequisite for merging https://github.com/Coalesce-Software-Inc/coalesce/pull/3288.