### PR TITLE
wrap numeric column names to preserve order

### DIFF
--- a/lib/connection/result/row_stream.js
+++ b/lib/connection/result/row_stream.js
@@ -382,7 +382,9 @@ function externalizeRow(row, columns, mapColumnIdToExtractFnName, rowMode) {
   for (let index = 0, length = columns.length; index < length; index++) {
     const column = columns[index];
     const extractFnName = mapColumnIdToExtractFnName[column.getId()];
-    externalizedRow[isArrayRowMode ? index : column.getName()] = row[extractFnName](column.getId());
+    // wrap only numeric column names in quotes to prevent JS property autosorting and retain proper columm order
+    const columnName = isNaN(column.getName()) ? column.getName() : `'${column.getName()}'`; 
+    externalizedRow[isArrayRowMode ? index : columnName] = row[extractFnName](column.getId());
   }
 
   return externalizedRow;


### PR DESCRIPTION
### Description
When adding properties to an object, Javascript puts numeric keys at the beginning. So when  processing row objects for external use, any numeric column names are taken out of order and put at the start. A `Map()` would technically be better than an object because it guarantees specified ordering where generic objects do not but changing that has wide reaching implications outside of this. Instead, wrap those numeric column name keys in quotes. Wrapping non-numeric in quotes does produce errors because of the different types of query results that get passed through here so this change is limited only to numeric ones.

NOTE: tests do pass locally

### Checklist
- [ ] Format code according to the existing code style (run `npm run lint:check -- CHANGED_FILES` and fix problems in changed code)
- [ ] Create tests which fail without the change (if possible)
- [ ] Make all tests (unit and integration) pass (`npm run test:unit` and `npm run test:integration`)
- [ ] Extend the types in index.d.ts file (if necessary)
- [ ] Extend the README / documentation and ensure is properly displayed (if necessary)
- [ ] Provide JIRA issue id (if possible) or GitHub issue id in commit message
